### PR TITLE
Added implementation of setup for the GDT.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -8,11 +8,12 @@ IF NOT EXIST /build mkdir build
 
 i686-elf-as kernel/boot.s -o build/boot.o
 i686-elf-as kernel/interrupt.s -o build/interrupt.o
+i686-elf-gcc -c kernel/gdt.c -o build/gdt.o -std=gnu99 -ffreestanding -O2 -Wall -Wextra
 i686-elf-gcc -c kernel/kernel.c -o build/kernel.o -std=gnu99 -ffreestanding -O2 -Wall -Wextra
 
 
 pushd build
-i686-elf-gcc -T ../linker.ld -o os.bin -ffreestanding -O2 -nostdlib boot.o interrupt.o kernel.o -lgcc
+i686-elf-gcc -T ../linker.ld -o os.bin -ffreestanding -O2 -nostdlib boot.o interrupt.o gdt.o kernel.o -lgcc
 popd
 
 qemu-system-i386 -kernel build/os.bin

--- a/kernel/gdt.c
+++ b/kernel/gdt.c
@@ -1,0 +1,90 @@
+#include <stdint.h>
+
+// TODO(Oskar): Magic values, fix me
+#define GRAN_64_BIT_MODE (1 << 5)
+#define GRAN_32_BIT_MODE (1 << 6)
+#define GRAN_4KIB_BLOCKS (1 << 7)
+
+struct tss_entry
+{
+    uint32_t prev_tss;
+    uint32_t esp0;
+    uint32_t ss0;
+    uint32_t esp1;
+    uint32_t ss1;
+    uint32_t esp2;
+    uint32_t ss2;
+    uint32_t cr3;
+    uint32_t eip;
+    uint32_t eflags;
+    uint32_t eax;
+    uint32_t ecx;
+    uint32_t edx;
+    uint32_t ebx;
+    uint32_t esp;
+    uint32_t ebp;
+    uint32_t esi;
+    uint32_t edi;
+    uint32_t es;
+    uint32_t cs;
+    uint32_t ss;
+    uint32_t ds;
+    uint32_t fs;
+    uint32_t gs;
+    uint32_t ldt;
+    uint16_t trap;
+    uint16_t iomap_base;
+};
+
+struct tss_entry tss = 
+{
+    .ss0 = 0x10,
+    .esp0 = 0,
+    .es = 0x10,
+    .cs = 0x08,
+    .ds = 0x13,
+    .fs = 0x13,
+    .gs = 0x13,
+};
+
+struct gdt_entry
+{
+    uint16_t LimitLow;
+    uint16_t BaseLow;
+    uint8_t BaseMiddle;
+    uint8_t Access;
+    uint8_t Granularity;
+    uint8_t BaseHigh;
+};
+
+#define GDT_ENTRY(Base, Limit, Access, Granularity) \
+    { (Limit) & 0xFFFF, \
+      (Base) >> 0 & 0xFFFF, \
+      (Base) >> 16 & 0xFF, \
+      (Access) & 0xFF, \
+      ((Limit) >> 16 & 0x0F) | ((Granularity) & 0xF0), \
+      (Base) >> 24 & 0xFF, \
+    }
+
+struct gdt_entry GDT[] =
+{
+    /* 0x00: Null segment */
+    GDT_ENTRY(0, 0, 0, 0),
+
+    /* 0x08: Kernel Code Segment. */
+    GDT_ENTRY(0, 0xFFFFFFFF, 0x9A, GRAN_32_BIT_MODE | GRAN_4KIB_BLOCKS),
+
+    /* 0x10: Kernel Data Segment. */
+    GDT_ENTRY(0, 0xFFFFFFFF, 0x92, GRAN_32_BIT_MODE | GRAN_4KIB_BLOCKS),
+
+    /* 0x18: User Code Segment. */
+    GDT_ENTRY(0, 0xFFFFFFFF, 0xFA, GRAN_32_BIT_MODE | GRAN_4KIB_BLOCKS),
+
+    /* 0x20: User Data Segment. */
+    GDT_ENTRY(0, 0xFFFFFFFF, 0xF2, GRAN_32_BIT_MODE | GRAN_4KIB_BLOCKS),
+
+    /* 0x28: Task Switch Segment. */
+    GDT_ENTRY(0 /*((uintptr_t) &tss)*/, sizeof(tss) - 1, 0xE9, 0x00),
+};
+
+uint16_t GDTSizeMinusOne = sizeof(GDT) - 1;

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -197,9 +197,8 @@ void kernel_main(void)
 	terminal_writestring("This\n should\n handle\n the\n newline\n character.\n");
   
 	terminal_writestring("Tabbing\t like\t crazy.\t PS.\t switch\t is\t the\t best\t control\t flow\t operator\t in\t the\t C\t language\t.\n");
-	terminal_writestring("A\nB\nC\nD\nE\nF\nG\nH\nI\nJ\nK\nL\nM\nN\nO\nP\nQ\nR\nS\nT\nU\nV\nW\nX\nY\nZ\n");
 	
 	terminal_writenumber(11230);
-	terminal_writestring("A\nB\nC\nD\nE\nF\nG\nH\nI\nJ\nK\nL\nM\nN\nO\nP\nQ\nR\nS\nT\nU\nV\nW\nX\nY\nZ");
+	terminal_writestring("\n");
 	asm volatile ("int $0x3"); // NOTE(Oskar): Triggers an ISR interrupt.
 }


### PR DESCRIPTION
Note that this setup of the GDT sets up the following segments:

* Null segment
* Kernel Code segment
* Kernel Data segment
* User Code segment
* User Data segment
* Task Switch segment

It is set up and initialized before kernel_main is called and is also compiled into its own object file and used in the bootloader.

When this is reviewed please make sure that the application is still running.

This issue solves #11 